### PR TITLE
Reverted color dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
-    "color": ">=0.11.3"
+    "color": "0.10.0"
   },
   "main": "index.js",
   "author": "Dan Chlopek"


### PR DESCRIPTION
We should actually adapt the new API but just calling rgb().array() doesn't help